### PR TITLE
Warning about reshuffle_each_iteration=True

### DIFF
--- a/tensorflow/python/data/ops/dataset_ops.py
+++ b/tensorflow/python/data/ops/dataset_ops.py
@@ -1404,7 +1404,7 @@ class DatasetV2(
     dataset = dataset.repeat(2)
     # [1, 0, 2, 1, 0, 2]
     ```
-
+    
     In TF 2.0, `tf.data.Dataset` objects are Python iterables which makes it
     possible to also create epochs through Python iteration:
 
@@ -1435,6 +1435,9 @@ class DatasetV2(
       reshuffle_each_iteration: (Optional.) A boolean, which if true indicates
         that the dataset should be pseudorandomly reshuffled each time it is
         iterated over. (Defaults to `True`.)
+        Note: Setting reshuffle_each_iteration = True may leads to data leakage.
+              Hence users should be careful while using 
+              reshuffle_each_iteration=True.
       name: (Optional.) A name for the tf.data operation.
 
     Returns:


### PR DESCRIPTION
tf.data.Dataset.shuffle has argument reshuffle_each_iteration which if set to True like  tf.data.Dataset.shuffle (reshuffle_each_iteration=True) which may lead to data leakage issue which is not desirable for model training. Please refer to attached [gist file](https://colab.research.google.com/gist/gaikwadrahul8/b54a085807b105be1a91c4f8e6957590/-59279.ipynb) demonstrating data leakage with this option.  Hence a warning note should be mentioned to make the users aware of it. Please review it and do the needful Thank you!